### PR TITLE
Require rails/test_unit/reporter in test_helper.rb

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 require "rails/test_help"
+require "rails/test_unit/reporter"
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.


### PR DESCRIPTION
When I ran `$ rake test`, I saw an error like below:

```
/Users/kenta.shirai/Repositories/leml/test/test_helper.rb:9:in `<top (required)>': uninitialized constant Rails::TestUnitReporter (NameError)
	from /Users/kenta.shirai/Repositories/leml/test/leml_test.rb:1:in `require'
	from /Users/kenta.shirai/Repositories/leml/test/leml_test.rb:1:in `<top (required)>'
	from /Users/kenta.shirai/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `require'
	from /Users/kenta.shirai/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
	from /Users/kenta.shirai/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `select'
	from /Users/kenta.shirai/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `<main>'
```

`Rails::TestUnitReporter` is defined in `railties/lib/rails/test_unit/reporter.rb` and it needs to be required.