### PR TITLE
add error classes, and messages

### DIFF
--- a/lib/leml/errors.rb
+++ b/lib/leml/errors.rb
@@ -1,0 +1,19 @@
+module Leml
+  class NoLemlKeyError < StandardError
+    def initialize
+      super("Leml key is not found. config. Please create `config/leml.key` and set the secret.\nFor further information, see: https://github.com/onunu/leml")
+    end
+  end
+
+  class NoEditorError < StandardError
+    def initialize
+      super("No editor, please set environment variable.\nex) EDITOR=vim bundle exec rake leml:edit")
+    end
+  end
+
+  class InvalidLemlKey < StandardError
+    def initialize
+      super("Key is invalid for decrypt, please check the value of `config/leml.key`")
+    end
+  end
+end

--- a/lib/leml/version.rb
+++ b/lib/leml/version.rb
@@ -1,3 +1,3 @@
 module Leml
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
# Raise error if it cannot found key, or cannot decrypt secrets
Until now, Initializing Rails is continued in each case of finding key,
It is difficult to find reason of error.
Now raise error when it is not found key, or fail to decrypt secrets.

# issue
#10 (by @kenta-s ) Thank you

# Change
- Add Error Class
- Raise error when it cannot found key, or fail to decrypt secrets