### PR TITLE
merge-friendly encryption

### DIFF
--- a/test/leml_test.rb
+++ b/test/leml_test.rb
@@ -1,7 +1,40 @@
 require 'test_helper'
+require 'yaml'
 
 class Leml::Test < ActiveSupport::TestCase
+  setup do
+    @leml = Leml::Core.new
+    def @leml.secrets
+      @secrets
+    end
+    def @leml.test_decrypt
+      decrypt(@secrets).to_yaml
+    end
+    def @leml.test_encrypt(raw_secrets)
+      encrypt(raw_secrets).to_yaml
+    end
+  end
+
   test "truth" do
     assert_kind_of Module, Leml
+  end
+
+  test "leml use same encrypted value when it did not edit" do
+    assert_equal @leml.secrets.to_yaml, @leml.test_encrypt(YAML.load(@leml.test_decrypt))
+  end
+
+  test "leml create other encrypted value when it edited" do
+    decrypt = YAML.load(@leml.test_decrypt)
+    decrypt['development']['author'] = decrypt['development']['author'] * 2
+    assert_not_equal @leml.secrets.to_yaml, @leml.test_encrypt(decrypt)
+  end
+
+  test "leml create other encrypted value only edited value" do
+    decrypt = YAML.load(@leml.test_decrypt)
+    decrypt['development']['new_value'] = "new_value"
+    re_encrypt = YAML.load(@leml.test_encrypt(decrypt))
+
+    assert_equal @leml.secrets.dig('development', 'author'), re_encrypt.dig('development', 'author')
+    assert_not_equal @leml.secrets.dig('development', 'new_value'), re_encrypt.dig('development', 'new_value')
   end
 end


### PR DESCRIPTION
hi, onunu.

Currently, leml changes all encrypted value when I change some value with leml:edit.
But I need some merge-friendly encryption.

for example, I have some encrypted key-value like this.
```yaml
---
development:
  aaa: Q3Jpc0Z2cWdycmlTSXk4V3FWcHVtUT09LS1RNHBkdlowOUJoRE4ranp5Sm0ydnRBPT0=--9477269966b8680370c4f49ca06bb2d9b33eeddc
  bbb: RmRDb2pPNTh0UGNjeVFLMWQvRHkrQT09LS04RG55dFdybmhna0Y2THhiSmZDeHdnPT0=--b13587bc82b8f527f59fe906ac24ad661800bc73
```

and then I change a value of "aaa". that re-encrypted all value like this.
```yaml
development:
  aaa: b2tHaVBvdG1qRE8xK0JwdjJXVUo1Zz09LS1TT0d3TFl0ODg3NnpoMGIyL2tPOXpnPT0=--97645be11032602c6f1e7b43609ce1c256112456
  bbb: OVlld2pDOE9yNnBtblRXSzhRNkQ0UT09LS1GQ2RqMjZvMCtVUjFLNndkeFNMV2dRPT0=--79ffef2e01464d919d9543e0de17f0512cda0026
```

So, I change value of "aaa" but "bbb" was changed too.
That is so hard to merge, check diff and so on.

I need same encrypted "bbb" value like this.
```yaml
---
development:
  aaa: cTJ1UDc2NzJVZ0tYTHUxekRuenBGdz09LS1ZT1lESlRncU1POXdlZUlxUU5taHBRPT0=--1e05f9795704696a5a0a443c5ffea72b91b2c234
  bbb: RmRDb2pPNTh0UGNjeVFLMWQvRHkrQT09LS04RG55dFdybmhna0Y2THhiSmZDeHdnPT0=--b13587bc82b8f527f59fe906ac24ad661800bc73
```
Here is changing only "aaa" value and exactly same encrypted "bbb" value before edit.

If you like it, merge this PR please.


Thanks.